### PR TITLE
feat: Add passlord to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,7 @@ Progress through each phase sequentially, but feel free to dive deeper into topi
 - [CrackMapExec](https://github.com/byt3bl33d3r/CrackMapExec) - Post-exploitation tool
 - [mimikatz](https://github.com/gentilkiwi/mimikatz) - Windows credential dumping
 - [RainbowCrack](http://project-rainbowcrack.com/) - Rainbow table implementation
+- [Passlord](https://github.com/navnee1h/passlord/) - Profile-based wordlist generator
 
 ### Forensics & Incident Response
 


### PR DESCRIPTION
This commit introduces 'passlord', a powerful profile-based wordlist generator, to the list of cybersecurity tools.

Passlord specializes in creating highly customized and targeted password lists from personal information, which is a crucial step in modern password cracking and dictionary attacks.

It has been placed in the 'Cryptography' section because its function directly complements existing tools like Hashcat and John the Ripper, which rely on quality wordlists as input.

Link: https://github.com/navnee1h/passlord/